### PR TITLE
Update unit-definitions.html

### DIFF
--- a/site/unit-definitions.html
+++ b/site/unit-definitions.html
@@ -27,7 +27,7 @@
 <th>Comment</th></tr>
 <tr><td>#</td><td>0.45359237</td><td>0</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>pound (mass)</td></tr>
 <tr><td>$</td><td>1</td><td>0</td><td>USD</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>1</td><td>US dollar</td></tr>
-<tr><td>&#x27;</td><td>0.3048</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>foot</td></tr>
+<tr><td>&#x2032;</td><td>0.3048</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>foot</td></tr>
 <tr><td>A</td><td>1</td><td>0</td><td>siSymbol</td><td>0</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>amperes</td></tr>
 <tr><td>AUD</td><td>1</td><td>0</td><td>AUD</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>1</td><td></td></tr>
 <tr><td>Adobe point</td><td><math><mfrac><mn>0.0254</mn><mn>72</mn></mfrac></math></td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>inch/72</td></tr>
@@ -549,7 +549,7 @@
 <tr><td>°R</td><td><math><mfrac><mn>5</mn><mn>9</mn></mfrac></math></td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>5/9 K</td></tr>
 <tr><td>Å</td><td>0.0000000001</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>angstrom</td></tr>
 <tr><td>Ω</td><td>1</td><td>0</td><td>siSymbol</td><td>2</td><td>1</td><td>-3</td><td>-2</td><td>0</td><td>0</td><td>0</td><td>0</td><td>ohm</td></tr>
-<tr><td>”</td><td>0.0254</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>Inch</td></tr>
+<tr><td>&#x2033;</td><td>0.0254</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>Inch</td></tr>
 <tr><td>₣</td><td>1</td><td>0</td><td>CHF</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>1</td><td>Swiss franc</td></tr>
 <tr><td>₨</td><td>1</td><td>0</td><td>INR</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>1</td><td>Indian Rupee</td></tr>
 <tr><td>₹</td><td>1</td><td>0</td><td>INR</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>1</td><td>Indian Rupee</td></tr>


### PR DESCRIPTION
Replaced single quote ' and double quote " with prime ′ and double prime ″ for feet and inches, respectively.

Might be a good idea to add a comment clarifying that the characters in question are prime and double prime, not single quote and double quote, as they look similar.

I also think a comment about how entering two single quotes then space will auto-correct to prime in the editor. Similarly, entering two double quotes then space will auto-correct to double prime in the editor. I'm pretty sure these comments will be long enough to require text wrapping and I don't understand the structure of the table enough to mess with it, so I'll leave it to @ronkok who I'm sure understands it much better.